### PR TITLE
Adjust settings for new coding conventions

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,12 +19,14 @@ module.exports = {
     'no-unused-vars': ['off'],
     // Use typescript version of "no-unused-vars" rule, because the default rule doesn't recognize certain typescript
     // features like enumerations
-    '@typescript-eslint/no-unused-vars': ['warn', { varsIgnorePattern: '^_', args: 'none' }],
+    '@typescript-eslint/no-unused-vars': ['warn', { args: 'none' }],
     'no-use-before-define': ['warn'],
 
-    // Prettier takes care of max length in code and eslint warns about prettier warnings due to the rule
-    // 'prettier/prettier'. Setting max-len to 120 for code here would add some linter warnings in code where prettier
-    // does not obey to the 120 char line length, so we're "supressing" it with 1000...
+    // Prettier takes care of max length in code and eslint warns about "unprettified code" due to the rule
+    // 'prettier/prettier'.
+    // Omiting the explicit setting for `code` here would make ESLint default to 80 chars max which stays in direct
+    // contrast to prettiers 120 char line length and setting it to 120 would still result in some linter warnings in
+    // code where prettier does not obey to the 120 char line length, so we're "supressing" it with 1000...
     'max-len': ['warn', { code: 1000, comments: 120 }],
 
     // Misc

--- a/index.js
+++ b/index.js
@@ -19,8 +19,13 @@ module.exports = {
     'no-unused-vars': ['off'],
     // Use typescript version of "no-unused-vars" rule, because the default rule doesn't recognize certain typescript
     // features like enumerations
-    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
-    'no-use-before-define': ['error', { functions: false }],
+    '@typescript-eslint/no-unused-vars': ['warn', { varsIgnorePattern: '^_', args: 'none' }],
+    'no-use-before-define': ['warn'],
+
+    // Prettier takes care of max length in code and eslint warns about prettier warnings due to the rule
+    // 'prettier/prettier'. Setting max-len to 120 for code here would add some linter warnings in code where prettier
+    // does not obey to the 120 char line length, so we're "supressing" it with 1000...
+    'max-len': ['warn', { code: 1000, comments: 120 }],
 
     // Misc
     'no-empty': ['warn', { allowEmptyCatch: true }],
@@ -28,5 +33,6 @@ module.exports = {
     // TS specific things
     '@typescript-eslint/ban-ts-comment': 'warn',
     '@typescript-eslint/explicit-module-boundary-types': 'warn',
+    '@typescript-eslint/explicit-function-return-type': 'warn',
   },
 };

--- a/index.js
+++ b/index.js
@@ -31,7 +31,13 @@ module.exports = {
     'no-empty': ['warn', { allowEmptyCatch: true }],
 
     // TS specific things
-    '@typescript-eslint/ban-ts-comment': 'warn',
+    '@typescript-eslint/ban-ts-comment': [
+      'warn',
+      {
+        'ts-expect-error': 'allow-with-description',
+        'ts-ignore': 'allow-with-description',
+      },
+    ],
     '@typescript-eslint/explicit-module-boundary-types': 'warn',
     '@typescript-eslint/explicit-function-return-type': 'warn',
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@combeenation/eslint-config",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@combeenation/eslint-config",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "Apache 2.0",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@combeenation/eslint-config",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
[Paymo Task](https://app.paymoapp.com/#Paymo.Projects/2013095/tasks/simple/task/22169148)

Adjusted ESLint to follow coding conventions as discussed 2 weeks ago:

* Also adhere to 120 chars per line for comments
* Change "used before defined" from error to warning
* Also require explicit return type for "private" function (which are not exported)

#CB-6659