### PR TITLE
Update/setting

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = {
     'no-unused-vars': ['off'],
     // Use typescript version of "no-unused-vars" rule, because the default rule doesn't recognize certain typescript
     // features like enumerations
-    '@typescript-eslint/no-unused-vars': ['warn', { args: 'none' }],
+    '@typescript-eslint/no-unused-vars': ['warn', { args: 'none', ignoreRestSiblings: true }],
     'no-use-before-define': ['off'],
 
     // Prettier takes care of max length in code and eslint warns about "unprettified code" due to the rule

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@combeenation/eslint-config",
-  "version": "1.0.1-rc1",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@combeenation/eslint-config",
-      "version": "1.0.1-rc1",
+      "version": "1.0.1",
       "license": "Apache 2.0",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "eslint-plugin-prettier": "^5.0.1"
       },
       "devDependencies": {
-        "@combeenation/prettier-config": "^1.0.0-rc1"
+        "@combeenation/prettier-config": "^1.0.0"
       },
       "peerDependencies": {
         "eslint": ">= 7"
@@ -300,9 +300,9 @@
       }
     },
     "node_modules/@combeenation/prettier-config": {
-      "version": "1.0.0-rc1",
-      "resolved": "https://registry.npmjs.org/@combeenation/prettier-config/-/prettier-config-1.0.0-rc1.tgz",
-      "integrity": "sha512-fHUGFoa7F+hLh+J33JfwLUYX5U/5yvjDjQ5efyhPsRZ0E/4K/wbu7NzM5UHC4QIPM0MCZPUGfrmU3REe3HbXJQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@combeenation/prettier-config/-/prettier-config-1.0.0.tgz",
+      "integrity": "sha512-ouuj0RwxxFjdt76211VZVZcQg2ff4LGmoXDTGHm0RPNUKDiOTFnArw9bPDcOlEutTGI1AC3QOAE8T7UJ4E9XWA==",
       "dev": true,
       "peerDependencies": {
         "@prettier/plugin-xml": "^3.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@combeenation/eslint-config",
-  "version": "1.0.0",
+  "version": "1.0.1-rc1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@combeenation/eslint-config",
-      "version": "1.0.0",
+      "version": "1.0.1-rc1",
       "license": "Apache 2.0",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.9.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-prettier": "^5.0.1"
   },
   "devDependencies": {
-    "@combeenation/prettier-config": "^1.0.0-rc1"
+    "@combeenation/prettier-config": "^1.0.0"
   },
   "peerDependencies": {
     "eslint": ">= 7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@combeenation/eslint-config",
-  "version": "1.0.0",
+  "version": "1.0.1-rc1",
   "description": "",
   "bugs": {
     "url": "https://github.com/Combeenation/cbn-eslint-config/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@combeenation/eslint-config",
-  "version": "1.0.1-rc1",
+  "version": "1.0.1",
   "description": "",
   "bugs": {
     "url": "https://github.com/Combeenation/cbn-eslint-config/issues"


### PR DESCRIPTION
One more change to `no-unused-vars` to allow stuff like the following without getting a warning:

```ts
const { unusedProperty1, unusedProperty2, usedProperty, ...rest } = someObject;
// Do something with `usedProperty` & `rest`, but not with `unusedProperty1` & `unusedProperty2`
```

Without the new setting `ignoreRestSiblings`, ESLint would have warned about `unusedProperty1` & `unusedProperty2` being unused which is sometimes required, when they should not be in the `rest` object...